### PR TITLE
Drop out-of-the-box support for Step serialization detour over Step[]

### DIFF
--- a/src/Core/Serialization/Serializer.cs
+++ b/src/Core/Serialization/Serializer.cs
@@ -144,14 +144,7 @@ namespace ExRam.Gremlinq.Core.Serialization
 
                     static void AddStep(Step step, Bytecode byteCode, bool isSourceStep, IGremlinQueryEnvironment env, ITransformer recurse)
                     {
-                        if (recurse.TryTransform(step, env, out Step[]? expandedSteps))
-                        {
-                            foreach (var innerExpandedStep in expandedSteps)
-                            {
-                                AddStep(innerExpandedStep, byteCode, isSourceStep, env, recurse);
-                            }
-                        }
-                        else if (recurse.TryTransform(step, env, out Step? expandedStep) && !ReferenceEquals(step, expandedStep))
+                        if (recurse.TryTransform(step, env, out Step? expandedStep) && !ReferenceEquals(step, expandedStep))
                             AddStep(expandedStep, byteCode, isSourceStep, env, recurse);
                         else if (recurse.TryTransform(step, env, out Traversal traversal))
                             AddTraversal(traversal, byteCode, env, recurse);

--- a/test/Tests.Infrastructure/QueryExecutionTest.cs
+++ b/test/Tests.Infrastructure/QueryExecutionTest.cs
@@ -4,6 +4,7 @@ using ExRam.Gremlinq.Core.GraphElements;
 using ExRam.Gremlinq.Core.Models;
 using ExRam.Gremlinq.Core.Steps;
 using ExRam.Gremlinq.Tests.Entities;
+using Gremlin.Net.Process.Traversal;
 using static ExRam.Gremlinq.Core.Transformation.ConverterFactory;
 using ExRam.Gremlinq.Core;
 using FluentAssertions;
@@ -1431,15 +1432,15 @@ namespace ExRam.Gremlinq.Tests.Infrastructure
         public Task Multi_step_serialization() => _g
             .ConfigureEnvironment(env => env
                 .ConfigureSerializer(ser => ser
-                    .Add(Create<EStep, Step[]>((_, env, _, recurse) => recurse
-                        .TransformTo<Step[]>()
-                        .From(
-                            new Step[]
-                            {
-                                new VStep(ImmutableArray<object>.Empty),
-                                new OutEStep(ImmutableArray<string>.Empty)
-                            },
-                            env)))))
+                    .Add(Create<EStep, Instruction[]>((_, env, _, recurse) =>
+                    [
+                        recurse
+                            .TransformTo<Instruction>()
+                            .From(new VStep(ImmutableArray<object>.Empty), env),
+                        recurse
+                            .TransformTo<Instruction>()
+                            .From(new OutEStep(ImmutableArray<string>.Empty), env)
+                    ]))))
             .E()
             .Verify();
 
@@ -1447,10 +1448,14 @@ namespace ExRam.Gremlinq.Tests.Infrastructure
         public Task Multi_step_serialization_with_forgotten_serialize() => _g
             .ConfigureEnvironment(env => env
                 .ConfigureSerializer(ser => ser
-                    .Add(Create<EStep, Step[]>((_, _, _, _) =>
+                    .Add(Create<EStep, Instruction[]>((_, _, _, recurse) =>
                     [
-                        new VStep(ImmutableArray<object>.Empty),
-                        new OutEStep(ImmutableArray<string>.Empty)
+                        recurse
+                            .TransformTo<Instruction>()
+                            .From(new VStep(ImmutableArray<object>.Empty), env),
+                        recurse
+                            .TransformTo<Instruction>()
+                            .From(new OutEStep(ImmutableArray<string>.Empty), env)
                     ]))))
             .E()
             .Verify();


### PR DESCRIPTION
If a custom converter goes this route, it must do the recursion itself through the recurse parameter to provide an Instruction[] instead. Two test are changed to demonstrate this.