### PR TITLE
Drop out-of-the-box support for Step serialization detour over Step.

### DIFF
--- a/src/Core/Serialization/Serializer.cs
+++ b/src/Core/Serialization/Serializer.cs
@@ -144,9 +144,7 @@ namespace ExRam.Gremlinq.Core.Serialization
 
                     static void AddStep(Step step, Bytecode byteCode, bool isSourceStep, IGremlinQueryEnvironment env, ITransformer recurse)
                     {
-                        if (recurse.TryTransform(step, env, out Step? expandedStep) && !ReferenceEquals(step, expandedStep))
-                            AddStep(expandedStep, byteCode, isSourceStep, env, recurse);
-                        else if (recurse.TryTransform(step, env, out Traversal traversal))
+                        if (recurse.TryTransform(step, env, out Traversal traversal))
                             AddTraversal(traversal, byteCode, env, recurse);
                         else if (recurse.TryTransform(step, env, out Instruction[]? expandedInstructions))
                         {

--- a/src/Providers.Neptune/Extensions/GremlinQuerySourceExtensions.cs
+++ b/src/Providers.Neptune/Extensions/GremlinQuerySourceExtensions.cs
@@ -90,8 +90,10 @@ namespace ExRam.Gremlinq.Providers.Neptune
                     .AddGraphSonBinarySupport()
                     .ConfigureSerializer(serializer => serializer
                         .Add(ConverterFactory
-                            .Create<PropertyStep.ByKeyStep, PropertyStep.ByKeyStep>((step, _, _, _) => Cardinality.List.Equals(step.Cardinality)
-                                ? new PropertyStep.ByKeyStep(step.Key, step.Value, step.MetaProperties, Cardinality.Set)
+                            .Create<PropertyStep.ByKeyStep, Instruction>((step, env, _, recurse) => Cardinality.List.Equals(step.Cardinality)
+                                ? recurse
+                                    .TransformTo<Instruction>()
+                                    .From(new PropertyStep.ByKeyStep(step.Key, step.Value, step.MetaProperties, Cardinality.Set), env)
                                 : null)))
                     .ConfigureDeserializer(deserializer => deserializer
                         .AsIncomplete())))


### PR DESCRIPTION
If a custom converter goes this route, it must do the recursion itself through the recurse parameter to provide an Instruction[] instead. Two test are changed to demonstrate this.