### PR TITLE
Drop out-of-the-box support for Step serialization detour over Traversal. 

### DIFF
--- a/src/Core/Serialization/Serializer.cs
+++ b/src/Core/Serialization/Serializer.cs
@@ -144,9 +144,7 @@ namespace ExRam.Gremlinq.Core.Serialization
 
                     static void AddStep(Step step, Bytecode byteCode, bool isSourceStep, IGremlinQueryEnvironment env, ITransformer recurse)
                     {
-                        if (recurse.TryTransform(step, env, out Traversal traversal))
-                            AddTraversal(traversal, byteCode, env, recurse);
-                        else if (recurse.TryTransform(step, env, out Instruction[]? expandedInstructions))
+                        if (recurse.TryTransform(step, env, out Instruction[]? expandedInstructions))
                         {
                             foreach (var expandedInstruction in expandedInstructions)
                             {


### PR DESCRIPTION
If a custom converter goes this route, it must do the recursion itself through the recurse parameter to provide an Instruction or Instruction[] instead.