### PR TITLE
Target all frameworks in all build configurations. 

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,7 @@
   <Import Project="../Directory.Build.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)'=='Release'">net8.0;net9.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
     <Product>ExRam.Gremlinq</Product>
     <Deterministic>true</Deterministic>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,8 +2,7 @@
   <Import Project="../Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Release'">net8.0;net9.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007;$(NoWarn)</NoWarn>


### PR DESCRIPTION
Local development in Debug mode will otherwise interfere with the packages.lock.json files.