### PR TITLE
Reuse underlying list in Traversal instead of creating a new one in every case

### DIFF
--- a/src/Core/Queries/Traversal.cs
+++ b/src/Core/Queries/Traversal.cs
@@ -81,26 +81,7 @@ namespace ExRam.Gremlinq.Core
                 var projectionTraversal = Projection.ToTraversal(environment);
 
                 if (projectionTraversal.Count > 0)
-                {
-                    var newSteps = FastImmutableList<Step>
-                        .Create(
-                            Count + projectionTraversal.Count,
-                            (_steps, projectionTraversal),
-                            static (newSteps, state) =>
-                            {
-                                var (steps, projectionTraversal) = state;
-
-                                steps
-                                    .AsSpan()
-                                    .CopyTo(newSteps);
-
-                                projectionTraversal
-                                    .Steps
-                                    .CopyTo(newSteps[steps.Count..]);
-                            });
-
-                    return new Traversal(newSteps, _writeStepsCount, Projection.Empty);
-                }
+                    return new Traversal(_steps.Push(projectionTraversal.Steps), _writeStepsCount, Projection.Empty);
             }
 
             return this;


### PR DESCRIPTION
## Changes

- **Performance Optimization**:
  - Modified `Traversal` to reuse the underlying list instead of creating a new list in every case
  - Reduces memory allocations and improves performance by avoiding unnecessary list creation