### PR TITLE
FastImmutableList review

### DIFF
--- a/src/Core/FastImmutableList.cs
+++ b/src/Core/FastImmutableList.cs
@@ -96,7 +96,7 @@ namespace ExRam.Gremlinq.Core
 
             if (Items.Length < count)
             {
-                var newItems = new T[count];
+                var newItems = new T[Math.Max(Items.Length * 2, count)];
 
                 this
                     .AsSpan()

--- a/src/Core/FastImmutableList.cs
+++ b/src/Core/FastImmutableList.cs
@@ -25,10 +25,10 @@ namespace ExRam.Gremlinq.Core
             if (newItems.Length > 0)
             {
                 var newListLength = Count + newItems.Length;
-                var newListSpan = EnsureCapacity(Math.Max(newListLength, 16))._items!.Value;
-                var targetSpan = newListSpan.Span[Count..];
+                var newListMemory = EnsureCapacity(Math.Max(newListLength, 16)).Items;
+                var targetSpan = newListMemory.Span[Count..];
 
-                if (newListSpan.Equals(_items!.Value))
+                if (newListMemory.Equals(Items))
                 {
                     //This instance is big enough, we need to guard the first element by Interlocked.
                     if (Interlocked.CompareExchange(ref targetSpan[0], newItems[0], null) != null)
@@ -39,7 +39,7 @@ namespace ExRam.Gremlinq.Core
                 }
 
                 ((ReadOnlySpan<T?>)newItems).CopyTo(targetSpan);
-                return new FastImmutableList<T>(newListSpan, newListLength);
+                return new FastImmutableList<T>(newListMemory, newListLength);
             }
 
             return this;

--- a/src/Core/FastImmutableList.cs
+++ b/src/Core/FastImmutableList.cs
@@ -25,7 +25,7 @@ namespace ExRam.Gremlinq.Core
             if (newItems.Length > 0)
             {
                 var newListLength = Count + newItems.Length;
-                var newListMemory = EnsureCapacity(Math.Max(newListLength, 16)).Items;
+                var newListMemory = EnsureCapacity(newListLength).Items;
                 var targetSpan = newListMemory.Span[Count..];
 
                 if (newListMemory.Equals(Items))
@@ -53,7 +53,7 @@ namespace ExRam.Gremlinq.Core
                 ? Interlocked.CompareExchange(ref steps.Span[Count], item, null) != null
                     ? Clone().Push(item)
                     : new FastImmutableList<T>(steps, Count + 1)
-                : EnsureCapacity(Math.Max(steps.Length * 2, 16)).Push(item);
+                : EnsureCapacity(steps.Length * 2).Push(item);
         }
 
         public FastImmutableList<T> Pop(out T poppedItem)
@@ -92,6 +92,8 @@ namespace ExRam.Gremlinq.Core
 
         public FastImmutableList<T> EnsureCapacity(int count)
         {
+            count = Math.Max(count, 16);
+
             if (Items.Length < count)
             {
                 var newItems = new T[count];

--- a/test/Benchmarks/FastImmutableListBenchmarks.cs
+++ b/test/Benchmarks/FastImmutableListBenchmarks.cs
@@ -37,5 +37,24 @@ namespace ExRam.Gremlinq.Benchmarks
         [Benchmark]
         public object Push_32() => _steps
             .Push(Steps32);
+
+        [Benchmark]
+        public object Push_4_multiple() => _steps
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4)
+            .Push(Steps4);
     }
 }

--- a/test/Benchmarks/FastImmutableListBenchmarks.cs
+++ b/test/Benchmarks/FastImmutableListBenchmarks.cs
@@ -39,22 +39,22 @@ namespace ExRam.Gremlinq.Benchmarks
             .Push(Steps32);
 
         [Benchmark]
-        public object Push_4_multiple() => _steps
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4)
-            .Push(Steps4);
+        public object Push_4_multiple() => _steps   //8, 16
+            .Push(Steps4)                           //12, 16
+            .Push(Steps4)                           //16, 16
+            .Push(Steps4)                           //20, 32
+            .Push(Steps4)                           //24, 32
+            .Push(Steps4)                           //28, 32
+            .Push(Steps4)                           //32, 32
+            .Push(Steps4)                           //36, 64
+            .Push(Steps4)                           //40, 64
+            .Push(Steps4)                           //44, 64
+            .Push(Steps4)                           //48, 64
+            .Push(Steps4)                           //52, 64
+            .Push(Steps4)                           //56, 64
+            .Push(Steps4)                           //60, 64
+            .Push(Steps4)                           //64, 64
+            .Push(Steps4)                           //68, 128
+            .Push(Steps4);                          //72, 128 => 16 + 32 + 64 + 128 = 240
     }
 }

--- a/test/Benchmarks/FastImmutableListBenchmarks.cs
+++ b/test/Benchmarks/FastImmutableListBenchmarks.cs
@@ -19,6 +19,10 @@ namespace ExRam.Gremlinq.Benchmarks
             .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local);
 
         [Benchmark]
+        public object Push_1() => _steps
+            .Push(CountStep.Local);
+
+        [Benchmark]
         public object Push_4() => _steps
             .Push(Steps4);
 

--- a/test/Core.Tests/FastImmutableListTest.cs
+++ b/test/Core.Tests/FastImmutableListTest.cs
@@ -41,5 +41,21 @@ namespace ExRam.Gremlinq.Core.Tests
                 .Should()
                 .Equal("1", "2", "3", "4");
         }
+
+        [Fact]
+        public void Push_empty()
+        {
+            var list = FastImmutableList<string>.Empty
+                .Push("1");
+
+            list = list
+                .Push([]);
+
+            list
+                .AsSpan()
+                .ToArray()
+                .Should()
+                .Equal("1");
+        }
     }
 }

--- a/test/Core.Tests/FastImmutableListTest.cs
+++ b/test/Core.Tests/FastImmutableListTest.cs
@@ -1,3 +1,4 @@
+using ExRam.Gremlinq.Core.Steps;
 using FluentAssertions;
 
 namespace ExRam.Gremlinq.Core.Tests
@@ -57,5 +58,24 @@ namespace ExRam.Gremlinq.Core.Tests
                 .Should()
                 .Equal("1");
         }
+
+        [Fact]
+        public void Push_multiple() => _ = FastImmutableList<Step>.Empty
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local)
+            .Push(CountStep.Local, CountStep.Local, CountStep.Local, CountStep.Local);
     }
 }


### PR DESCRIPTION
## Changes

- **Testing**:
  - Added test for empty `Push` to `FastImmutableList` to ensure edge case handling
  - Added new benchmarks for debugging and performance analysis

- **Maintenance**:
  - Used `Value` property for better code clarity and consistency
  - Ensured a minimum size of 16 in `EnsureCapacity` method
  - Grow by a factor of at least 2 when growing the list to maintain amortized O(1) performance