### PR TITLE
Cache empty VStep and EStep

### DIFF
--- a/src/Core/Extensions/TraversalExtensions.cs
+++ b/src/Core/Extensions/TraversalExtensions.cs
@@ -20,10 +20,6 @@ namespace ExRam.Gremlinq.Core
 
         public static SideEffectSemanticsChange GetSideEffectSemanticsChange(this Traversal traversal) => (SideEffectSemanticsChange)traversal.SideEffectSemantics;
 
-        public static SideEffectSemanticsChange GetSideEffectSemanticsChange(this Traversal? maybeTraversal) => maybeTraversal is { } traversal
-            ? traversal.GetSideEffectSemanticsChange()
-            : SideEffectSemanticsChange.None;
-
         public static Traversal Rewrite(this Traversal traversal, ContinuationFlags flags)
         {
             if (traversal is [NoneStep, ..])

--- a/src/Core/Queries/GremlinQuery.cs
+++ b/src/Core/Queries/GremlinQuery.cs
@@ -604,7 +604,9 @@ namespace ExRam.Gremlinq.Core
             .Continue()
             .Build(
                 static (builder, ids) => builder
-                    .AddStep(new EStep(ids.ToImmutableArray()))
+                    .AddStep(ids.Length == 0
+                        ? EStep.NoIds
+                        : new EStep(ids.ToImmutableArray()))
                     .OfType(SanitizedFilterTypesCache<object, TNewElement>.Types, builder.OuterQuery.Environment.Model.EdgesModel)
                     .WithNewProjection(Projection.Edge)
                     .BuildAuto<TNewElement>(),
@@ -1262,7 +1264,9 @@ namespace ExRam.Gremlinq.Core
             .Continue()
             .Build(
                 static (builder, ids) => builder
-                    .AddStep(new VStep(ids.ToImmutableArray()))
+                    .AddStep(ids.Length == 0
+                        ? VStep.NoIds
+                        : new VStep(ids.ToImmutableArray()))
                     .OfType(SanitizedFilterTypesCache<object, TNewElement>.Types, builder.OuterQuery.Environment.Model.VerticesModel)
                     .WithNewProjection(Projection.Vertex)
                     .BuildAuto<TNewElement>(),

--- a/src/Core/Steps/ChoosePredicateStep.cs
+++ b/src/Core/Steps/ChoosePredicateStep.cs
@@ -10,7 +10,7 @@ namespace ExRam.Gremlinq.Core.Steps
         /// <param name="predicate">The predicate condition.</param>
         /// <param name="thenTraversal">The traversal to execute when the predicate is true.</param>
         /// <param name="elseTraversal">The optional traversal to execute when the predicate is false.</param>
-        public ChoosePredicateStep(P predicate, Traversal thenTraversal, Traversal? elseTraversal = null) : base(thenTraversal, elseTraversal, thenTraversal.GetSideEffectSemanticsChange() | elseTraversal.GetSideEffectSemanticsChange())
+        public ChoosePredicateStep(P predicate, Traversal thenTraversal, Traversal? elseTraversal = null) : base(thenTraversal, elseTraversal, thenTraversal.GetSideEffectSemanticsChange() | (elseTraversal?.GetSideEffectSemanticsChange() ?? SideEffectSemanticsChange.None))
         {
             ArgumentNullException.ThrowIfNull(predicate);
 

--- a/src/Core/Steps/ChooseTraversalStep.cs
+++ b/src/Core/Steps/ChooseTraversalStep.cs
@@ -8,7 +8,7 @@ namespace ExRam.Gremlinq.Core.Steps
         /// <param name="ifTraversal">The condition traversal.</param>
         /// <param name="thenTraversal">The traversal to execute when the condition is true.</param>
         /// <param name="elseTraversal">The optional traversal to execute when the condition is false.</param>
-        public ChooseTraversalStep(Traversal ifTraversal, Traversal thenTraversal, Traversal? elseTraversal = null) : base(thenTraversal, elseTraversal, ifTraversal.GetSideEffectSemanticsChange() | thenTraversal.GetSideEffectSemanticsChange() | elseTraversal.GetSideEffectSemanticsChange())
+        public ChooseTraversalStep(Traversal ifTraversal, Traversal thenTraversal, Traversal? elseTraversal = null) : base(thenTraversal, elseTraversal, ifTraversal.GetSideEffectSemanticsChange() | thenTraversal.GetSideEffectSemanticsChange() | (elseTraversal?.GetSideEffectSemanticsChange() ?? SideEffectSemanticsChange.None))
         {
             IfTraversal = ifTraversal;
         }

--- a/src/Core/Steps/EStep.cs
+++ b/src/Core/Steps/EStep.cs
@@ -6,6 +6,11 @@ namespace ExRam.Gremlinq.Core.Steps
     /// <seealso href="https://tinkerpop.apache.org/docs/current/reference/#graph-step">Reference Documentation - Graph Step</seealso>
     public sealed class EStep : Step
     {
+        /// <summary>
+        ///  Static instance of <see cref="EStep"/> representing a call to the E() operator without any ids passed. 
+        /// </summary>
+        public static readonly EStep Empty = new (ImmutableArray<object>.Empty);
+
         /// <summary>Initializes a new instance of <see cref="EStep"/> with the specified edge identifiers.</summary>
         /// <param name="ids">The edge identifiers to read.</param>
         public EStep(ImmutableArray<object> ids)

--- a/src/Core/Steps/EStep.cs
+++ b/src/Core/Steps/EStep.cs
@@ -9,7 +9,7 @@ namespace ExRam.Gremlinq.Core.Steps
         /// <summary>
         ///  Static instance of <see cref="EStep"/> representing a call to the E() operator without any ids passed. 
         /// </summary>
-        public static readonly EStep Empty = new (ImmutableArray<object>.Empty);
+        public static readonly EStep NoIds = new (ImmutableArray<object>.Empty);
 
         /// <summary>Initializes a new instance of <see cref="EStep"/> with the specified edge identifiers.</summary>
         /// <param name="ids">The edge identifiers to read.</param>

--- a/src/Core/Steps/VStep.cs
+++ b/src/Core/Steps/VStep.cs
@@ -9,7 +9,7 @@ namespace ExRam.Gremlinq.Core.Steps
         /// <summary>
         ///  Static instance of <see cref="VStep"/> representing a call to the V() operator without any ids passed. 
         /// </summary>
-        public static readonly VStep Empty = new (ImmutableArray<object>.Empty);
+        public static readonly VStep NoIds = new (ImmutableArray<object>.Empty);
 
         /// <summary>Initializes a new instance of <see cref="VStep"/> with the specified vertex identifiers.</summary>
         /// <param name="ids">The vertex identifiers to read.</param>

--- a/src/Core/Steps/VStep.cs
+++ b/src/Core/Steps/VStep.cs
@@ -6,6 +6,11 @@ namespace ExRam.Gremlinq.Core.Steps
     /// <seealso href="https://tinkerpop.apache.org/docs/current/reference/#graph-step">Reference Documentation - Graph Step</seealso>
     public sealed class VStep : Step
     {
+        /// <summary>
+        ///  Static instance of <see cref="VStep"/> representing a call to the V() operator without any ids passed. 
+        /// </summary>
+        public static readonly VStep Empty = new (ImmutableArray<object>.Empty);
+
         /// <summary>Initializes a new instance of <see cref="VStep"/> with the specified vertex identifiers.</summary>
         /// <param name="ids">The vertex identifiers to read.</param>
         public VStep(ImmutableArray<object> ids)

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet10_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet10_0.verified.cs
@@ -3103,6 +3103,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class VStep : ExRam.Gremlinq.Core.Steps.Step
     {
+        public static readonly ExRam.Gremlinq.Core.Steps.VStep Empty;
         public VStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet10_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet10_0.verified.cs
@@ -2610,6 +2610,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class EStep : ExRam.Gremlinq.Core.Steps.Step
     {
+        public static readonly ExRam.Gremlinq.Core.Steps.EStep Empty;
         public EStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet10_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet10_0.verified.cs
@@ -2610,7 +2610,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class EStep : ExRam.Gremlinq.Core.Steps.Step
     {
-        public static readonly ExRam.Gremlinq.Core.Steps.EStep Empty;
+        public static readonly ExRam.Gremlinq.Core.Steps.EStep NoIds;
         public EStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }
@@ -3104,7 +3104,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class VStep : ExRam.Gremlinq.Core.Steps.Step
     {
-        public static readonly ExRam.Gremlinq.Core.Steps.VStep Empty;
+        public static readonly ExRam.Gremlinq.Core.Steps.VStep NoIds;
         public VStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
@@ -3103,6 +3103,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class VStep : ExRam.Gremlinq.Core.Steps.Step
     {
+        public static readonly ExRam.Gremlinq.Core.Steps.VStep Empty;
         public VStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
@@ -2610,6 +2610,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class EStep : ExRam.Gremlinq.Core.Steps.Step
     {
+        public static readonly ExRam.Gremlinq.Core.Steps.EStep Empty;
         public EStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
@@ -2610,7 +2610,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class EStep : ExRam.Gremlinq.Core.Steps.Step
     {
-        public static readonly ExRam.Gremlinq.Core.Steps.EStep Empty;
+        public static readonly ExRam.Gremlinq.Core.Steps.EStep NoIds;
         public EStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }
@@ -3104,7 +3104,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class VStep : ExRam.Gremlinq.Core.Steps.Step
     {
-        public static readonly ExRam.Gremlinq.Core.Steps.VStep Empty;
+        public static readonly ExRam.Gremlinq.Core.Steps.VStep NoIds;
         public VStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
@@ -3103,6 +3103,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class VStep : ExRam.Gremlinq.Core.Steps.Step
     {
+        public static readonly ExRam.Gremlinq.Core.Steps.VStep Empty;
         public VStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
@@ -2610,6 +2610,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class EStep : ExRam.Gremlinq.Core.Steps.Step
     {
+        public static readonly ExRam.Gremlinq.Core.Steps.EStep Empty;
         public EStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
@@ -2610,7 +2610,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class EStep : ExRam.Gremlinq.Core.Steps.Step
     {
-        public static readonly ExRam.Gremlinq.Core.Steps.EStep Empty;
+        public static readonly ExRam.Gremlinq.Core.Steps.EStep NoIds;
         public EStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }
@@ -3104,7 +3104,7 @@ namespace ExRam.Gremlinq.Core.Steps
     }
     public sealed class VStep : ExRam.Gremlinq.Core.Steps.Step
     {
-        public static readonly ExRam.Gremlinq.Core.Steps.VStep Empty;
+        public static readonly ExRam.Gremlinq.Core.Steps.VStep NoIds;
         public VStep(System.Collections.Immutable.ImmutableArray<object> ids) { }
         public System.Collections.Immutable.ImmutableArray<object> Ids { get; }
     }


### PR DESCRIPTION
## Changes

- **Performance Optimization**:
  - Removed extension method that was trivial to inline for better performance
  - Added static instances of empty `VStep` and `EStep` to avoid repeated allocations
  - Renamed static fields on `VStep` and `EStep` for better code clarity
  - Used static instances of `VStep` and `EStep` where applicable to reduce memory allocations and improve performance