### PR TITLE
Update actions/checkout and actions/setup-dotnet to Node 24 releases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # 6.0.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/checkPullRequest.yml
+++ b/.github/workflows/checkPullRequest.yml
@@ -16,14 +16,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #4.1.14
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       with:
         fetch-depth: 0
         submodules: 'true'
         token: ${{ secrets.CHECKOUT_TOKEN }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # 4.2.0
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # 6.0.0
       with:
         global-json-file: global.json
         dotnet-version: |

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       with:
         fetch-depth: 0
         submodules: 'true'
         token: ${{ secrets.CHECKOUT_TOKEN }}
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # 4.3.1
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # 6.0.0
       with:
         global-json-file: global.json
         dotnet-version: |

--- a/.github/workflows/pushPreview.yml
+++ b/.github/workflows/pushPreview.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # 4.3.1
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # 6.0.0
       with:
         dotnet-version: 10
           

--- a/.github/workflows/pushStable.yml
+++ b/.github/workflows/pushStable.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # 4.3.1
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # 6.0.0
       with:
         dotnet-version: 10
 


### PR DESCRIPTION
GitHub deprecated Node.js 20 runners for Actions
(https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

- actions/checkout: 4.1.14/4.2.2/4.3.1 (node20) -> 7.0.1 (node24)
- actions/setup-dotnet: 4.2.0/4.3.1 (node20) -> 6.0.0 (node24)

Both are non-breaking major bumps (ESM migration + dependency bumps only; inputs/outputs unchanged). actions/checkout@08c6903cd8... (v5.0.0) in announce.yml was already on node24 and left unchanged.

Note: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea, also named in the deprecation warning, does not appear anywhere in this repository's workflow files (checked all of .github/workflows and .github/*.yml). It's likely invoked by a GitHub-managed default workflow (e.g. CodeQL default setup) configured via repository Settings rather than a checked-in file, or is a transitive dependency of one of the third-party actions used here. This could not be fixed from within the repository.