### PR TITLE
Save allocation of a separate StepLabel identity

### DIFF
--- a/src/Core/Queries/StepLabel.cs
+++ b/src/Core/Queries/StepLabel.cs
@@ -21,7 +21,9 @@ namespace ExRam.Gremlinq.Core
         public virtual StepLabel<TNewValue> Cast<TNewValue>() => new(Identity);
 
         /// <inheritdoc />
-        public bool Equals(StepLabel? other) => Identity.Equals(other?.Identity);
+        public bool Equals(StepLabel? other) => ReferenceEquals(Identity, this)
+            ? base.Equals(other?.Identity)
+            : Identity.Equals(other?.Identity);
 
         /// <inheritdoc />
         public override bool Equals(object? obj)
@@ -39,7 +41,9 @@ namespace ExRam.Gremlinq.Core
         }
 
         /// <inheritdoc />
-        public override int GetHashCode() => Identity.GetHashCode();
+        public override int GetHashCode() => ReferenceEquals(Identity, this)
+            ? base.GetHashCode()
+            : Identity.GetHashCode();
 
         /// <summary>Tests two step labels for equality.</summary>
         public static bool operator ==(StepLabel? left, StepLabel? right) => Equals(left, right);

--- a/src/Core/Queries/StepLabel.cs
+++ b/src/Core/Queries/StepLabel.cs
@@ -6,8 +6,9 @@ namespace ExRam.Gremlinq.Core
     public abstract class StepLabel : IEquatable<StepLabel>
     {
         /// <summary>Initializes a new <see cref="StepLabel"/> with a unique identity.</summary>
-        protected StepLabel() : this(new object())
-        { 
+        protected StepLabel()
+        {
+            Identity = this;
         }
 
         internal StepLabel(object identity)

--- a/test/Core.Tests/StepLabelTest.cs
+++ b/test/Core.Tests/StepLabelTest.cs
@@ -64,5 +64,11 @@ namespace ExRam.Gremlinq.Core.Tests
 
             stepLabel1.Should().Be(stepLabel2);
         }
+
+        [Fact]
+        public void GetHashCode_terminates() => new StepLabel<object>()
+            .GetHashCode()
+            .Should()
+            .NotBe(0);
     }
 }


### PR DESCRIPTION
The StepLabel instance itself is perfectly fine to be used.