### PR TITLE
Handle concurrent dispose/creation during container creation

### DIFF
--- a/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
+++ b/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
@@ -131,6 +131,10 @@ namespace ExRam.Gremlinq.Support.TestContainers
 
                             return newContainer;
                         }
+
+                        await newContainer
+                            .DisposeAsync()
+                            .ConfigureAwait(false);
                     }
                 }
             }


### PR DESCRIPTION
Dispose a freshly built container when the CompareExchange loses to a concurrent dispose/creation.