### PR TITLE
Stop and Dispose Testcontainers container through executor/client-factory disposal

### DIFF
--- a/src/Core/Execution/GremlinQueryExecutor.cs
+++ b/src/Core/Execution/GremlinQueryExecutor.cs
@@ -104,9 +104,15 @@ namespace ExRam.Gremlinq.Core.Execution
                 _baseExecutor = baseExecutor;
             }
 
-            public ValueTask DisposeAsync() => _baseExecutor is IAsyncDisposable asyncDisposable
-                ? asyncDisposable.DisposeAsync()
-                : ValueTask.CompletedTask;
+            public ValueTask DisposeAsync()
+            {
+                using (_semaphore)
+                {
+                    return _baseExecutor is IAsyncDisposable asyncDisposable
+                        ? asyncDisposable.DisposeAsync()
+                        : ValueTask.CompletedTask;
+                }
+            }
 
             public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {

--- a/src/Core/Execution/GremlinQueryExecutor.cs
+++ b/src/Core/Execution/GremlinQueryExecutor.cs
@@ -21,7 +21,7 @@ namespace ExRam.Gremlinq.Core.Execution
             public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context) => AsyncEnumerable.Empty<T>();
         }
 
-        private sealed class TransformQueryGremlinQueryExecutor : IGremlinQueryExecutor
+        private sealed class TransformQueryGremlinQueryExecutor : IGremlinQueryExecutor, IAsyncDisposable
         {
             private readonly IGremlinQueryExecutor _baseExecutor;
             private readonly Func<IGremlinQueryBase, IGremlinQueryBase> _transformation;
@@ -31,6 +31,10 @@ namespace ExRam.Gremlinq.Core.Execution
                 _transformation = transformation;
                 _baseExecutor = baseExecutor;
             }
+
+            public ValueTask DisposeAsync() => _baseExecutor is IAsyncDisposable asyncDisposable
+                ? asyncDisposable.DisposeAsync()
+                : ValueTask.CompletedTask;
 
             public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {
@@ -46,7 +50,7 @@ namespace ExRam.Gremlinq.Core.Execution
             }
         }
 
-        private sealed class TransformExecutionExceptionGremlinQueryExecutor : IGremlinQueryExecutor
+        private sealed class TransformExecutionExceptionGremlinQueryExecutor : IGremlinQueryExecutor, IAsyncDisposable
         {
             private readonly IGremlinQueryExecutor _baseExecutor;
             private readonly Func<GremlinQueryExecutionException, GremlinQueryExecutionException> _exceptionTransformation;
@@ -56,6 +60,10 @@ namespace ExRam.Gremlinq.Core.Execution
                 _baseExecutor = baseExecutor;
                 _exceptionTransformation = exceptionTransformation;
             }
+
+            public ValueTask DisposeAsync() => _baseExecutor is IAsyncDisposable asyncDisposable
+                ? asyncDisposable.DisposeAsync()
+                : ValueTask.CompletedTask;
 
             public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {
@@ -86,7 +94,7 @@ namespace ExRam.Gremlinq.Core.Execution
             }
         }
 
-        private sealed class SerializingGremlinQueryExecutor : IGremlinQueryExecutor
+        private sealed class SerializingGremlinQueryExecutor : IGremlinQueryExecutor, IAsyncDisposable
         {
             private readonly SemaphoreSlim _semaphore = new(1);
             private readonly IGremlinQueryExecutor _baseExecutor;
@@ -95,6 +103,10 @@ namespace ExRam.Gremlinq.Core.Execution
             {
                 _baseExecutor = baseExecutor;
             }
+
+            public ValueTask DisposeAsync() => _baseExecutor is IAsyncDisposable asyncDisposable
+                ? asyncDisposable.DisposeAsync()
+                : ValueTask.CompletedTask;
 
             public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {

--- a/src/Providers.Core/Factory/GremlinqClientFactory.cs
+++ b/src/Providers.Core/Factory/GremlinqClientFactory.cs
@@ -19,7 +19,7 @@ namespace ExRam.Gremlinq.Providers.Core
     /// </summary>
     public static class GremlinqClientFactory
     {
-        private sealed class PoolGremlinqClientFactory<TBaseFactory> : IPoolGremlinqClientFactory<TBaseFactory>
+        private sealed class PoolGremlinqClientFactory<TBaseFactory> : IPoolGremlinqClientFactory<TBaseFactory>, IAsyncDisposable
             where TBaseFactory : IGremlinqClientFactory
         {
             private sealed class PoolGremlinqClient : IGremlinqClient
@@ -184,6 +184,10 @@ namespace ExRam.Gremlinq.Providers.Core
             public IGremlinqClient Create(IGremlinQueryEnvironment environment) => _clientTransformation(new PoolGremlinqClient(_baseFactory, _poolSize, _maxInProcessPerConnection, environment), environment);
 
             public IPoolGremlinqClientFactory<TBaseFactory> ConfigureClient(Func<IGremlinqClient, IGremlinQueryEnvironment, IGremlinqClient> clientTransformation) => new PoolGremlinqClientFactory<TBaseFactory>(_baseFactory, _poolSize, _maxInProcessPerConnection, (client, env) => clientTransformation(_clientTransformation(client, env), env));
+
+            public ValueTask DisposeAsync() => _baseFactory is IAsyncDisposable asyncDisposable
+                ? asyncDisposable.DisposeAsync()
+                : ValueTask.CompletedTask;
         }
 
         private sealed class GremlinQueryExecutorImpl : IGremlinQueryExecutor, IAsyncDisposable

--- a/src/Providers.Core/Factory/GremlinqClientFactory.cs
+++ b/src/Providers.Core/Factory/GremlinqClientFactory.cs
@@ -186,7 +186,7 @@ namespace ExRam.Gremlinq.Providers.Core
             public IPoolGremlinqClientFactory<TBaseFactory> ConfigureClient(Func<IGremlinqClient, IGremlinQueryEnvironment, IGremlinqClient> clientTransformation) => new PoolGremlinqClientFactory<TBaseFactory>(_baseFactory, _poolSize, _maxInProcessPerConnection, (client, env) => clientTransformation(_clientTransformation(client, env), env));
         }
 
-        private sealed class GremlinQueryExecutorImpl : IGremlinQueryExecutor
+        private sealed class GremlinQueryExecutorImpl : IGremlinQueryExecutor, IAsyncDisposable
         {
             private static readonly ConcurrentDictionary<Type, Func<GremlinQueryExecutorImpl, GremlinQueryExecutionContext, object>> MetaResponseDelegates = new();
 
@@ -197,6 +197,10 @@ namespace ExRam.Gremlinq.Providers.Core
             {
                 _clientFactory = clientFactory;
             }
+
+            public ValueTask DisposeAsync() => _clientFactory is IAsyncDisposable asyncDisposable
+                ? asyncDisposable.DisposeAsync()
+                : ValueTask.CompletedTask;
 
             public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {

--- a/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
+++ b/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
@@ -94,9 +94,14 @@ namespace ExRam.Gremlinq.Support.TestContainers
 
             public IGremlinqClient Create(IGremlinQueryEnvironment environment) => new ContainerGremlinClient(this, environment);
 
-            public ValueTask DisposeAsync() => Interlocked.Exchange(ref _container, DisposedObject) is IContainer container
-                ? container.DisposeAsync()
-                : ValueTask.CompletedTask;
+            public async ValueTask DisposeAsync()
+            {
+                if (Interlocked.Exchange(ref _container, DisposedObject) is IContainer container)
+                    await container.DisposeAsync().ConfigureAwait(false);
+
+                if (_baseFactory is IAsyncDisposable asyncDisposable)
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
 
             public IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(Func<IWebSocketGremlinqClientFactory, TNewBaseFactory> transformation) where TNewBaseFactory : IGremlinqClientFactory => throw new NotSupportedException();
 

--- a/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
+++ b/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
@@ -13,7 +13,7 @@ namespace ExRam.Gremlinq.Support.TestContainers
     /// <summary>Configurator for creating a client factory that is backed by a Testcontainers container.</summary>
     public readonly struct TestContainersWithContainerConfigurator
     {
-        private sealed class ContainerGremlinqClientFactory : IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>
+        private sealed class ContainerGremlinqClientFactory : IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>, IAsyncDisposable
         {
             private sealed class ContainerGremlinClient : IGremlinqClient
             {
@@ -93,6 +93,10 @@ namespace ExRam.Gremlinq.Support.TestContainers
             }
 
             public IGremlinqClient Create(IGremlinQueryEnvironment environment) => new ContainerGremlinClient(this, environment);
+
+            public ValueTask DisposeAsync() => Interlocked.Exchange(ref _container, DisposedObject) is IContainer container
+                ? container.DisposeAsync()
+                : ValueTask.CompletedTask;
 
             public IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(Func<IWebSocketGremlinqClientFactory, TNewBaseFactory> transformation) where TNewBaseFactory : IGremlinqClientFactory => throw new NotSupportedException();
 

--- a/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
+++ b/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
@@ -97,7 +97,14 @@ namespace ExRam.Gremlinq.Support.TestContainers
             public async ValueTask DisposeAsync()
             {
                 if (Interlocked.Exchange(ref _container, DisposedObject) is IContainer container)
-                    await container.DisposeAsync().ConfigureAwait(false);
+                {
+                    await using (container.ConfigureAwait(false))
+                    {
+                        await container
+                            .StopAsync()
+                            .ConfigureAwait(false);
+                    }
+                }
 
                 if (_baseFactory is IAsyncDisposable asyncDisposable)
                     await asyncDisposable.DisposeAsync().ConfigureAwait(false);

--- a/test/Core.Tests/GremlinQueryExecutorTest.cs
+++ b/test/Core.Tests/GremlinQueryExecutorTest.cs
@@ -221,6 +221,36 @@ namespace ExRam.Gremlinq.Core.Tests
         }
 
         [Fact]
+        public async Task Serialize_dispose_twice_does_not_throw()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor>();
+
+            var executor = baseExecutor
+                .Serialize();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+            await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Serialize_disposed_executor_rejects_new_executions()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor>();
+
+            var executor = baseExecutor
+                .Serialize();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            await executor
+                .Execute<int>(GremlinQueryExecutionContext.Create(_query))
+                .Awaiting(x => x
+                    .ToArrayAsync(TestContext.Current.CancellationToken))
+                .Should()
+                .ThrowAsync<ObjectDisposedException>();
+        }
+
+        [Fact]
         public async Task Executor_from_environment_disposes_wrapped_base_executor()
         {
             var baseExecutor = Substitute.For<IGremlinQueryExecutor, IAsyncDisposable>();

--- a/test/Core.Tests/GremlinQueryExecutorTest.cs
+++ b/test/Core.Tests/GremlinQueryExecutorTest.cs
@@ -131,6 +131,113 @@ namespace ExRam.Gremlinq.Core.Tests
         }
 
         [Fact]
+        public async Task TransformQuery_disposes_base_executor_if_IAsyncDisposable()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor, IAsyncDisposable>();
+
+            var executor = baseExecutor
+                .TransformQuery(_ => _);
+
+            executor
+                .Should()
+                .BeAssignableTo<IAsyncDisposable>();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            await ((IAsyncDisposable)baseExecutor)
+                .Received(1)
+                .DisposeAsync();
+        }
+
+        [Fact]
+        public async Task TransformQuery_dispose_without_IAsyncDisposable_base_does_not_throw()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor>();
+
+            var executor = baseExecutor
+                .TransformQuery(_ => _);
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+
+        [Fact]
+        public async Task TransformExecutionException_disposes_base_executor_if_IAsyncDisposable()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor, IAsyncDisposable>();
+
+            var executor = baseExecutor
+                .TransformExecutionException(ex => ex);
+
+            executor
+                .Should()
+                .BeAssignableTo<IAsyncDisposable>();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            await ((IAsyncDisposable)baseExecutor)
+                .Received(1)
+                .DisposeAsync();
+        }
+
+        [Fact]
+        public async Task TransformExecutionException_dispose_without_IAsyncDisposable_base_does_not_throw()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor>();
+
+            var executor = baseExecutor
+                .TransformExecutionException(ex => ex);
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Serialize_disposes_base_executor_if_IAsyncDisposable()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor, IAsyncDisposable>();
+
+            var executor = baseExecutor
+                .Serialize();
+
+            executor
+                .Should()
+                .BeAssignableTo<IAsyncDisposable>();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            await ((IAsyncDisposable)baseExecutor)
+                .Received(1)
+                .DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Serialize_dispose_without_IAsyncDisposable_base_does_not_throw()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor>();
+
+            var executor = baseExecutor
+                .Serialize();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Executor_from_environment_disposes_wrapped_base_executor()
+        {
+            var baseExecutor = Substitute.For<IGremlinQueryExecutor, IAsyncDisposable>();
+
+            var environment = GremlinQueryEnvironment.Invalid
+                .UseExecutor(baseExecutor
+                    .TransformExecutionException(ex => ex));
+
+            if (environment.Executor is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+
+            await ((IAsyncDisposable)baseExecutor)
+                .Received(1)
+                .DisposeAsync();
+        }
+
+        [Fact]
         public void TransformQuery_throws_on_null_executor()
         {
             var act = () => GremlinQueryExecutor.TransformQuery(null!, _ => _);

--- a/test/Providers.Core.Tests/GremlinQueryExecutorDisposalTests.cs
+++ b/test/Providers.Core.Tests/GremlinQueryExecutorDisposalTests.cs
@@ -1,4 +1,5 @@
 using ExRam.Gremlinq.Core;
+using ExRam.Gremlinq.Core.Execution;
 
 using FluentAssertions;
 
@@ -64,6 +65,24 @@ namespace ExRam.Gremlinq.Providers.Core.Tests
                 .ToExecutor();
 
             await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Executor_from_environment_disposes_wrapped_factory_executor()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory, IAsyncDisposable>();
+
+            var environment = GremlinQueryEnvironment.Invalid
+                .UseExecutor(factory
+                    .ToExecutor()
+                    .TransformExecutionException(ex => ex));
+
+            if (environment.Executor is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+
+            await ((IAsyncDisposable)factory)
+                .Received(1)
+                .DisposeAsync();
         }
     }
 }

--- a/test/Providers.Core.Tests/GremlinQueryExecutorDisposalTests.cs
+++ b/test/Providers.Core.Tests/GremlinQueryExecutorDisposalTests.cs
@@ -84,5 +84,38 @@ namespace ExRam.Gremlinq.Providers.Core.Tests
                 .Received(1)
                 .DisposeAsync();
         }
+
+        [Fact(Skip = "Fails until GremlinQueryExecutorImpl disposes cached clients on disposal.")]
+        public async Task Executor_dispose_disposes_cached_clients()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory, IAsyncDisposable>();
+            var client = Substitute.For<IGremlinqClient>();
+
+            factory
+                .Create(Arg.Any<IGremlinQueryEnvironment>())
+                .Returns(client);
+
+            var executor = factory.ToExecutor();
+
+            try
+            {
+                await foreach (var _ in executor.Execute<object>(GremlinQueryExecutionContext.Create(GremlinQuerySource.g.V())))
+                {
+                }
+            }
+            catch
+            {
+            }
+
+            factory
+                .Received(1)
+                .Create(Arg.Any<IGremlinQueryEnvironment>());
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            client
+                .Received(1)
+                .Dispose();
+        }
     }
 }

--- a/test/Providers.Core.Tests/GremlinQueryExecutorDisposalTests.cs
+++ b/test/Providers.Core.Tests/GremlinQueryExecutorDisposalTests.cs
@@ -1,0 +1,69 @@
+using ExRam.Gremlinq.Core;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+namespace ExRam.Gremlinq.Providers.Core.Tests
+{
+    public class GremlinQueryExecutorDisposalTests
+    {
+        [Fact]
+        public async Task Executor_from_environment_disposes_factory_if_IAsyncDisposable()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory, IAsyncDisposable>();
+
+            var environment = GremlinQueryEnvironment.Invalid
+                .UseExecutor(factory.ToExecutor());
+
+            if (environment.Executor is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+
+            await ((IAsyncDisposable)factory)
+                .Received(1)
+                .DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Executor_dispose_without_IAsyncDisposable_factory_does_not_throw()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>();
+
+            var executor = factory.ToExecutor();
+
+            executor
+                .Should()
+                .BeAssignableTo<IAsyncDisposable>();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Pool_factory_disposes_base_factory_if_IAsyncDisposable()
+        {
+            var baseFactory = Substitute.For<IGremlinqClientFactory, IAsyncDisposable>();
+
+            var executor = baseFactory
+                .Pool()
+                .ToExecutor();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            await ((IAsyncDisposable)baseFactory)
+                .Received(1)
+                .DisposeAsync();
+        }
+
+        [Fact]
+        public async Task Pool_factory_dispose_without_IAsyncDisposable_base_does_not_throw()
+        {
+            var baseFactory = Substitute.For<IGremlinqClientFactory>();
+
+            var executor = baseFactory
+                .Pool()
+                .ToExecutor();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+        }
+    }
+}

--- a/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -44,7 +44,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -44,7 +44,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.StringKey.verified.txt
+++ b/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.StringKey.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -47,7 +47,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.GremlinServer.Tests/GroovyIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -47,7 +47,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationTests.StringKey.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationTests.StringKey.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -48,7 +48,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -48,7 +48,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.StringKey.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.StringKey.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.GremlinServer.Tests/IntegrationWithoutProjectionTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -45,7 +45,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     log: {
       Level: Debug,
@@ -67,7 +67,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
           Message: ServerErrorFailStep: There's been an error.
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     log: {
       Level: Debug,
@@ -67,7 +67,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
           Message: ServerErrorFailStep: fail() step triggered
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.StringKey.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.StringKey.verified.txt
@@ -70,7 +70,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
           Message: ServerError: Expected an id that is convertible to class java.lang.Long but received class java.lang.String - [id]
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -70,7 +70,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
           Message: ServerError: Expected an id that is convertible to class java.lang.Long but received class java.lang.String - [12345678-9012-3456-7890-123456789012]
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     log: {
       Level: Debug,
@@ -70,7 +70,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
           Message: ServerErrorFailStep: There's been an error.
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     log: {
       Level: Debug,
@@ -70,7 +70,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
           Message: ServerErrorFailStep: fail() step triggered
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.StringKey.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.StringKey.verified.txt
@@ -73,7 +73,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
           Message: ServerError: Expected an id that is convertible to class java.lang.Long but received class java.lang.String - [id]
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.GremlinServer.Tests/LoggingWithBindingsIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -73,7 +73,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
           Message: ServerError: Expected an id that is convertible to class java.lang.Long but received class java.lang.String - [12345678-9012-3456-7890-123456789012]
         },
         StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -45,7 +45,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.StringKey.verified.txt
+++ b/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.StringKey.verified.txt
@@ -48,7 +48,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.GremlinServer.Tests/ObjectQueryIntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -48,7 +48,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ElementMap.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ElementMap.verified.txt
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ElementMap_Cast.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ElementMap_Cast.verified.txt
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -48,7 +48,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -48,7 +48,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceE.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceE.verified.txt
@@ -63,7 +63,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceE_With_Config.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceE_With_Config.verified.txt
@@ -63,7 +63,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceV.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceV.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -66,7 +66,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceV_With_Config.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.ReplaceV_With_Config.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -63,7 +63,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.V_single_untyped.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.V_single_untyped.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_Id_equals_constant.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_Id_equals_constant.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_Values_Id_Where.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_Values_Id_Where.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_converted_Id_equals_constant.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_converted_Id_equals_constant.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_outside_model.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_outside_model.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_property_equals_local_string_constant.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_property_equals_local_string_constant.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_property_equals_value_of_anonymous_object.verified.txt
+++ b/test/Providers.GremlinServer.Tests/StringIdIntegrationTests.Where_property_equals_value_of_anonymous_object.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -51,7 +51,7 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.Fail_with_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -44,7 +44,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.Fail_without_message.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -44,7 +44,7 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.Properties_Where_Id.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.Properties_Where_Id.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -47,7 +47,7 @@ java.lang.NullPointerException: Expected valid relation id: id
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.Properties_Where_Id_equals_static_field.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.Properties_Where_Id_equals_static_field.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -47,7 +47,7 @@ java.lang.NullPointerException: Expected valid relation id: id
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.StringKey.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.StringKey.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -62,7 +62,7 @@ java.lang.NumberFormatException: For input string: "id"
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -52,7 +52,7 @@ java.lang.NumberFormatException: For input string: "12345678-9012-3456-7890-1234
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.JanusGraph.Tests/IntegrationTests.Where_VertexProperty_Id.verified.txt
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.Where_VertexProperty_Id.verified.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   Type: GremlinQueryExecutionException,
   ExecutionContext: {
     ExecutionId: 12345678-9012-3456-7890-123456789012,
@@ -59,7 +59,7 @@ java.lang.NullPointerException: Expected valid relation id: 36
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__4`1.<Execute>b__4_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
+at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.<>c__5`1.<Execute>b__5_0(GremlinQueryExecutionContext context, RequestMessage _, ResponseMessage`1 response)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)
 at ExRam.Gremlinq.Providers.Core.GremlinqClientFactory.GremlinQueryExecutorImpl.Execute[TResult,TTransformedResult](GremlinQueryExecutionContext context, Func`4 resultTransformation, CancellationToken ct)

--- a/test/Providers.Neptune.Tests/IntegrationTests.Fail_with_message.verified.txt
+++ b/test/Providers.Neptune.Tests/IntegrationTests.Fail_with_message.verified.txt
@@ -45,9 +45,9 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at ExRam.Gremlinq.Tests.Infrastructure.ExecutingVerifier.Verify[TElement](IGremlinQueryBase`1 query)

--- a/test/Providers.Neptune.Tests/IntegrationTests.Fail_without_message.verified.txt
+++ b/test/Providers.Neptune.Tests/IntegrationTests.Fail_without_message.verified.txt
@@ -45,9 +45,9 @@ org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.FailStep$FailExce
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at ExRam.Gremlinq.Tests.Infrastructure.ExecutingVerifier.Verify[TElement](IGremlinQueryBase`1 query)

--- a/test/Providers.Neptune.Tests/IntegrationTests.StringKey.verified.txt
+++ b/test/Providers.Neptune.Tests/IntegrationTests.StringKey.verified.txt
@@ -48,9 +48,9 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at ExRam.Gremlinq.Tests.Infrastructure.ExecutingVerifier.Verify[TElement](IGremlinQueryBase`1 query)

--- a/test/Providers.Neptune.Tests/IntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
+++ b/test/Providers.Neptune.Tests/IntegrationTests.Where_Id_equals_toStringed_Guid.verified.txt
@@ -48,9 +48,9 @@ java.lang.IllegalArgumentException: Expected an id that is convertible to class 
     Data: {}
   },
   StackTrace:
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
-at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|3_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
+at ExRam.Gremlinq.Core.Execution.GremlinQueryExecutor.TransformExecutionExceptionGremlinQueryExecutor.<Execute>g__Core|4_0[T](TransformExecutionExceptionGremlinQueryExecutor this, GremlinQueryExecutionContext context, CancellationToken ct)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at System.Linq.AsyncEnumerable.<ToArrayAsync>g__Impl|179_0[TSource](ConfiguredCancelableAsyncEnumerable`1 source)
 at ExRam.Gremlinq.Tests.Infrastructure.ExecutingVerifier.Verify[TElement](IGremlinQueryBase`1 query)

--- a/test/Support.TestContainers.Tests/ContainerTeardownTests.cs
+++ b/test/Support.TestContainers.Tests/ContainerTeardownTests.cs
@@ -1,0 +1,79 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+using ExRam.Gremlinq.Core;
+using ExRam.Gremlinq.Support.NewtonsoftJson;
+using ExRam.Gremlinq.Providers.GremlinServer;
+using ExRam.Gremlinq.Tests.Entities;
+using ExRam.Gremlinq.Tests.Infrastructure;
+
+using FluentAssertions;
+
+namespace ExRam.Gremlinq.Support.TestContainers.Tests
+{
+    [IntegrationTest("Linux", true)]
+    [IntegrationTest("Windows")]
+    public class ContainerTeardownTests
+    {
+        [Fact]
+        public async Task Disposing_the_executor_tears_down_the_container()
+        {
+            IContainer? startedContainer = null;
+
+            var g = GremlinQuerySource.g
+                .UseGremlinServer<Vertex, Edge>(configurator => configurator
+                    .UseTestContainers(c => c
+                        .ConfigureContainer(builder => builder
+                            .WithImage("ghcr.io/gremlinq/gremlin-server-mod:3")
+                            .WithPortBinding(8182, true)
+                            .WithWaitStrategy(Wait
+                                .ForUnixContainer()
+                                .UntilInternalTcpPortIsAvailable(8182)))
+                        .ConfigureClientFactory((poolFactory, container) =>
+                        {
+                            startedContainer = container;
+
+                            return poolFactory
+                                .ConfigureBaseFactory(webSocketFactory => webSocketFactory
+                                    .ConfigureUri(_ => new Uri($"ws://localhost:{container.GetMappedPublicPort(8182)}")));
+                        }))
+                    .UseNewtonsoftJson());
+
+            var result = await g
+                .Inject(1, 2, 3)
+                .Sum()
+                .FirstAsync(TestContext.Current.CancellationToken);
+
+            result
+                .Should()
+                .Be(6);
+
+            startedContainer
+                .Should()
+                .NotBeNull();
+
+            startedContainer!
+                .State
+                .Should()
+                .Be(TestcontainersStates.Running);
+
+            var executor = g
+                .AsAdmin()
+                .Environment
+                .Executor;
+
+            executor
+                .Should()
+                .BeAssignableTo<IAsyncDisposable>();
+
+            await ((IAsyncDisposable)executor).DisposeAsync();
+
+            await Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            
+            startedContainer
+                .State
+                .Should()
+                .NotBe(TestcontainersStates.Running);
+        }
+    }
+}

--- a/test/Tests.Infrastructure/GremlinqFixture.cs
+++ b/test/Tests.Infrastructure/GremlinqFixture.cs
@@ -18,7 +18,13 @@ namespace ExRam.Gremlinq.Tests.Infrastructure
                 .UseModel(GraphModel.FromBaseTypes<Vertex, Edge>())
                 .AddGraphSonBinarySupport()));
 
-        public virtual async ValueTask DisposeAsync() => GC.SuppressFinalize(this);
+        public virtual async ValueTask DisposeAsync()
+        {
+            if (_g?.AsAdmin().Environment.Executor is IAsyncDisposable disposableExecutor)
+                await disposableExecutor.DisposeAsync().ConfigureAwait(false);
+
+            GC.SuppressFinalize(this);
+        }
 
         public virtual IGremlinQuerySource GetQuerySource() => _g ?? throw new InvalidOperationException();
     }


### PR DESCRIPTION
Adds a deterministic teardown path for Testcontainers-backed resources: the client-factory/executor chain now implements `IAsyncDisposable`, so disposing the query source's executor stops and disposes the underlying container.

## Changes

- **Support.TestContainers**: `ContainerGremlinqClientFactory` implements `IAsyncDisposable`; disposal stops (before disposing) and disposes the container, then forwards disposal to the wrapped pool factory when it is `IAsyncDisposable`.
- **Providers.Core**: `GremlinQueryExecutorImpl` (via `ToExecutor()`) and `PoolGremlinqClientFactory` implement `IAsyncDisposable` and forward disposal to their wrapped factory.
- **Core**: the wrapping executors `TransformQuery`, `TransformExecutionException` and `Serialize` implement `IAsyncDisposable` and forward disposal to the wrapped executor when it is `IAsyncDisposable`. `SerializingGremlinQueryExecutor` additionally disposes its `SemaphoreSlim` (via a `using` block) on disposal.
- **Test infrastructure**: `GremlinqFixture.DisposeAsync` disposes the environment's executor when it is `IAsyncDisposable`, so test containers are torn down with the fixture.
- **Tests**:
  - Unit tests covering the disposal hand-down chain for executors and client factories.
  - `ContainerTeardownTests` integration test asserting the container leaves the `Running` state after the executor is disposed.
  - A skipped test (`Executor_dispose_disposes_cached_clients`) documenting a follow-up: disposing clients cached by the executor on disposal.
  - Updated stack-trace snapshots affected by the executor changes.

## Notes

- `IGremlinQueryExecutor` and `IGremlinqClientFactory` are unchanged — no public API break; disposal is discovered via `is IAsyncDisposable` checks.
